### PR TITLE
Updated to support Typescript

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,4 @@
 node_modules
 package-lock.json
+.yalc
+yalc.lock

--- a/README.md
+++ b/README.md
@@ -16,10 +16,10 @@ First, to be able to use the library, install it first using the following comma
 npm install pastebin-scraper --save
 ```
 
-This library is a promise-based library, so you first must require it in your code and then import the function `scrape`:
+This library is a promise-based library, so you first must require it in your code and then import the function `Scrape`:
 ```javascript
-const {scrape} = require('pastebin-scraper');
-scrape('https://pastebin.com/4Z489JeC')
+const {Scrape} = require('pastebin-scraper');
+Scrape('https://pastebin.com/4Z489JeC')
 .then(res => console.log(res))
 ```
 

--- a/README.md
+++ b/README.md
@@ -11,18 +11,19 @@
 [![Awesome](https://cdn.rawgit.com/sindresorhus/awesome/d7305f38d29fed78fa85652e3a63e154dd8e8829/media/badge.svg)](https://github.com/sindresorhus/awesome)
 
 ### *Usage* ###
-First, to be able to use the library, install it first using the following command
+First, to be able to use the library, install it first using the following command:
+```bash
+npm install pastebin-scraper --save
 ```
-$ npm install pastebin-scraper --save
-```
-This library is a promise-based library, so you first must require it in your code and then use it somewhat like this.
+
+This library is a promise-based library, so you first must require it in your code and then import the function `scrape`:
 ```javascript
-const {scrape} = require('pastebin-scraper')
+const {scrape} = require('pastebin-scraper');
 scrape('https://pastebin.com/4Z489JeC')
 .then(res => console.log(res))
 ```
 
-Output looks something like this
+Output will be an object, which can be accessed using properties.
 ```bash
 {
   title: 'Pastebin Scraper',
@@ -34,6 +35,7 @@ Output looks something like this
   language: 'text'
 }
 ```
+
 You can run this test this library in the tryit.js folder if you are, for example, running this library in GitHub or Replit.
 <br>
-*v1.0.1*
+*v1.1.0*

--- a/README.md
+++ b/README.md
@@ -38,4 +38,4 @@ Output will be an object, which can be accessed using properties.
 
 You can run this test this library in the tryit.js folder if you are, for example, running this library in GitHub or Replit.
 <br>
-*v1.1.0*
+*v2.0.0*

--- a/README.md
+++ b/README.md
@@ -2,9 +2,9 @@
 
 [![NPM License](https://img.shields.io/npm/l/all-contributors.svg?style=flat)](https://github.com/exoticchild-alt/pastebin-scraper/blob/master/LICENSE)
 [![NPM Downloads](https://img.shields.io/npm/dt/pastebin-scraper.svg?style=flat)]()   
-[![NPM](https://nodei.co/npm/pastebin-scraper.png?downloads=true)](https://www.npmjs.com/pastebin-scraper) 
+[![NPM](https://nodei.co/npm/pastebin-scraper.png?downloads=true)](https://www.npmjs.com/pastebin-scraper)
 <br>
-[![GitHub Release](https://img.shields.io/github/release/exoticchild-alt/pastebin-scraper.svg?style=flat)]() 
+[![GitHub Release](https://img.shields.io/github/release/exoticchild-alt/pastebin-scraper.svg?style=flat)]()
 [![Issues](https://img.shields.io/github/issues-raw/exoticchild-alt/pastebin-scraper.svg?maxAge=25000)](https://github.com/exoticchild-alt/pastebin-scraper/issues)  
 [![run on repl.it](https://repl.it/badge/github/exoticchild-alt/pastebin-scraper)](https://repl.it/github/exoticchild-alt/pastebin-scraper)
 [![Open Source](https://badges.frapsoft.com/os/v1/open-source.svg?v=103)](https://opensource.org/)
@@ -17,12 +17,13 @@ $ npm install pastebin-scraper --save
 ```
 This library is a promise-based library, so you first must require it in your code and then use it somewhat like this.
 ```javascript
-const scrape = require('pastebin-scraper')
+const {scrape} = require('pastebin-scraper')
 scrape('https://pastebin.com/4Z489JeC')
 .then(res => console.log(res))
-//response looks something like this
+```
 
-/*
+Output looks something like this
+```bash
 {
   title: 'Pastebin Scraper',
   views: '8',
@@ -32,8 +33,7 @@ scrape('https://pastebin.com/4Z489JeC')
   dateCreated: 'Aug 15th, 2021',
   language: 'text'
 }
-*/
 ```
-You can run this test this library in the tryit.js folder if you are, for example, running this library in Github or Replit.
+You can run this test this library in the tryit.js folder if you are, for example, running this library in GitHub or Replit.
 <br>
 *v1.0.1*

--- a/dist/index.d.ts
+++ b/dist/index.d.ts
@@ -1,0 +1,9 @@
+export declare function scrape(url: string): Promise<{
+    title: string;
+    views: string;
+    rawData: string;
+    user: string;
+    expiration: string;
+    dateCreated: string;
+    language: string;
+}>;

--- a/dist/index.d.ts
+++ b/dist/index.d.ts
@@ -1,4 +1,4 @@
-export declare function scrape(url: string): Promise<{
+export declare function Scrape(url: string): Promise<{
     title: string;
     views: string;
     rawData: string;

--- a/dist/index.js
+++ b/dist/index.js
@@ -9,10 +9,10 @@ var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, ge
     });
 };
 Object.defineProperty(exports, "__esModule", { value: true });
-exports.scrape = void 0;
+exports.Scrape = void 0;
 const cheerio = require("cheerio");
 const axios = require('axios').default;
-function scrape(url) {
+function Scrape(url) {
     return __awaiter(this, void 0, void 0, function* () {
         const response = yield axios.get(url);
         const $ = cheerio.load(response.data);
@@ -27,4 +27,4 @@ function scrape(url) {
         };
     });
 }
-exports.scrape = scrape;
+exports.Scrape = Scrape;

--- a/dist/index.js
+++ b/dist/index.js
@@ -1,0 +1,30 @@
+"use strict";
+var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, generator) {
+    function adopt(value) { return value instanceof P ? value : new P(function (resolve) { resolve(value); }); }
+    return new (P || (P = Promise))(function (resolve, reject) {
+        function fulfilled(value) { try { step(generator.next(value)); } catch (e) { reject(e); } }
+        function rejected(value) { try { step(generator["throw"](value)); } catch (e) { reject(e); } }
+        function step(result) { result.done ? resolve(result.value) : adopt(result.value).then(fulfilled, rejected); }
+        step((generator = generator.apply(thisArg, _arguments || [])).next());
+    });
+};
+Object.defineProperty(exports, "__esModule", { value: true });
+exports.scrape = void 0;
+const cheerio = require("cheerio");
+const axios = require('axios').default;
+function scrape(url) {
+    return __awaiter(this, void 0, void 0, function* () {
+        const response = yield axios.get(url);
+        const $ = cheerio.load(response.data);
+        return {
+            title: $("body > div.wrap > div.container > div.content > div.post-view > div.details > div.info-bar > div.info-top > h1").text(),
+            views: $("body > div.wrap > div.container > div.content > div.post-view > div.details > div.info-bar > div.info-bottom > div.visits").text().replace("\n", "").trim(),
+            rawData: $("body > div.wrap > div.container > div.content > div.post-view > textarea").text(),
+            user: $("body > div.wrap > div.container > div.content > div.post-view > div.details > div.info-bar > div.info-bottom > div.username > a").text(),
+            expiration: $("body > div.wrap > div.container > div.content > div.post-view > div.details > div.info-bar > div.info-bottom > div.expire").text().replace("\n", "").trim(),
+            dateCreated: $("body > div.wrap > div.container > div.content > div.post-view > div.details > div.info-bar > div.info-bottom > div.date > span").text(),
+            language: $("body > div.wrap > div.container > div.content > div.post-view > div.highlighted-code > div.top-buttons > div.left > a").text()
+        };
+    });
+}
+exports.scrape = scrape;

--- a/lib/index.ts
+++ b/lib/index.ts
@@ -1,11 +1,11 @@
-const cheerio = require('cheerio');
-const axios = require('axios');
-module.exports = async function(url) {
+import cheerio = require('cheerio');
+const axios = require('axios').default;
+export async function scrape(url: string) {
     const response = await axios.get(url);
     const $ = cheerio.load(response.data);
     return {
         title: $("body > div.wrap > div.container > div.content > div.post-view > div.details > div.info-bar > div.info-top > h1").text(),
-        views: $("body > div.wrap > div.container > div.content > div.post-view > div.details > div.info-bar > div.info-bottom > div.visits").text().replace("\n", "").trim(), 
+        views: $("body > div.wrap > div.container > div.content > div.post-view > div.details > div.info-bar > div.info-bottom > div.visits").text().replace("\n", "").trim(),
         rawData: $("body > div.wrap > div.container > div.content > div.post-view > textarea").text(),
         user: $("body > div.wrap > div.container > div.content > div.post-view > div.details > div.info-bar > div.info-bottom > div.username > a").text(),
         expiration: $("body > div.wrap > div.container > div.content > div.post-view > div.details > div.info-bar > div.info-bottom > div.expire").text().replace("\n", "").trim(),

--- a/lib/index.ts
+++ b/lib/index.ts
@@ -1,6 +1,6 @@
 import cheerio = require('cheerio');
 const axios = require('axios').default;
-export async function scrape(url: string) {
+export async function Scrape(url: string) {
     const response = await axios.get(url);
     const $ = cheerio.load(response.data);
     return {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pastebin-scraper",
-  "version": "1.1.0",
+  "version": "2.0.0",
   "description": "A simple library that scrapes data about pastes from Pastebin",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pastebin-scraper",
-  "version": "1.0.1",
+  "version": "1.1.0",
   "description": "A simple library that scrapes data about pastes from Pastebin",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
@@ -8,7 +8,7 @@
     "prepublish": "npm run build",
     "pretest": "yalc publish && yalc add pastebin-scraper",
     "test": "node tryit.js",
-    "tsconfig": " cd node_modules/.bin/ && tsc --init",
+    "tsc-init": " cd node_modules/.bin/ && tsc --init",
     "build": "tsc"
   },
   "repository": {
@@ -24,8 +24,7 @@
   "homepage": "https://github.com/exoticchild-alt/pastebin-scraper#readme",
   "dependencies": {
     "axios": "^0.24.0",
-    "cheerio": "^1.0.0-rc.10",
-    "pastebin-scraper": "file:.yalc/pastebin-scraper"
+    "cheerio": "^1.0.0-rc.10"
   },
   "devDependencies": {
     "@types/node": "^16.11.7",

--- a/package.json
+++ b/package.json
@@ -2,23 +2,21 @@
   "name": "pastebin-scraper",
   "version": "1.0.1",
   "description": "A simple library that scrapes data about pastes from Pastebin",
-  "main": "index.js",
+  "main": "dist/index.js",
+  "types": "dist/index.d.ts",
   "scripts": {
+    "prepublish": "npm run build",
     "pretest": "yalc publish && yalc add pastebin-scraper",
-    "test": "node tryit.js"
+    "test": "node tryit.js",
+    "tsconfig": " cd node_modules/.bin/ && tsc --init",
+    "build": "tsc"
   },
   "repository": {
     "type": "git",
     "url": "git+https://github.com/exoticchild-alt/pastebin-scraper.git"
   },
-  "keywords": [
-    "pastebin",
-    "scraper",
-    "web",
-    "cheerio",
-    "axios"
-  ],
-  "author": "",
+  "keywords": ["pastebin", "scraper", "web", "cheerio", "axios"],
+  "author": "https://github.com/exoticchild",
   "license": "MIT",
   "bugs": {
     "url": "https://github.com/exoticchild-alt/pastebin-scraper/issues"
@@ -30,6 +28,8 @@
     "pastebin-scraper": "file:.yalc/pastebin-scraper"
   },
   "devDependencies": {
+    "@types/node": "^16.11.7",
+    "typescript": "^4.4.4",
     "yalc": "^1.0.0-pre.53"
   }
 }

--- a/package.json
+++ b/package.json
@@ -4,13 +4,20 @@
   "description": "A simple library that scrapes data about pastes from Pastebin",
   "main": "index.js",
   "scripts": {
-    "test": "echo \"Error: no test specified\" && exit 1"
+    "pretest": "yalc publish && yalc add pastebin-scraper",
+    "test": "node tryit.js"
   },
   "repository": {
     "type": "git",
     "url": "git+https://github.com/exoticchild-alt/pastebin-scraper.git"
   },
-  "keywords": ["pastebin", "scraper", "web", "cheerio", "axios"],
+  "keywords": [
+    "pastebin",
+    "scraper",
+    "web",
+    "cheerio",
+    "axios"
+  ],
   "author": "",
   "license": "MIT",
   "bugs": {
@@ -18,7 +25,11 @@
   },
   "homepage": "https://github.com/exoticchild-alt/pastebin-scraper#readme",
   "dependencies": {
-    "axios": "^0.21.1",
-    "cheerio": "^1.0.0-rc.10"
+    "axios": "^0.24.0",
+    "cheerio": "^1.0.0-rc.10",
+    "pastebin-scraper": "file:.yalc/pastebin-scraper"
+  },
+  "devDependencies": {
+    "yalc": "^1.0.0-pre.53"
   }
 }

--- a/tryit.js
+++ b/tryit.js
@@ -1,4 +1,7 @@
 //here you can try this library
-//const pastebin = require('pastebin-scraper')
-const {scrape} = require('pastebin-scraper')
-scrape('https://pastebin.com/4Z489JeC').then(res => console.log(res))
+//const {scrape} = require('pastebin-scraper')
+const {scrape} = require('pastebin-scraper');
+const res = scrape('https://pastebin.com/4Z489JeC')
+.then(res => console.log(res));
+//console.log(res);
+console.log(typeof res);

--- a/tryit.js
+++ b/tryit.js
@@ -1,7 +1,7 @@
 //here you can try this library
 //const {scrape} = require('pastebin-scraper')
-const {scrape} = require('pastebin-scraper');
-const res = scrape('https://pastebin.com/4Z489JeC')
+const {Scrape} = require('pastebin-scraper');
+const res = Scrape('https://pastebin.com/4Z489JeC')
 .then(res => console.log(res));
 //console.log(res);
 console.log(typeof res);

--- a/tryit.js
+++ b/tryit.js
@@ -1,4 +1,4 @@
 //here you can try this library
 //const pastebin = require('pastebin-scraper')
-const scrape = require('pastebin-scraper')
+const {scrape} = require('pastebin-scraper')
 scrape('https://pastebin.com/4Z489JeC').then(res => console.log(res))

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,10 @@
+{
+  "compilerOptions": {
+    "target": "es6",
+    "module": "commonjs",
+    "declaration": true,
+    "outDir": "./dist",
+    "strict": true,
+    "moduleResolution": "node"
+  }
+}


### PR DESCRIPTION
Updated the module to support Typescript.

Typescript requires you to have an identifier for the return function, for which the README.MD is updated.

Also updated tryit.js accordingly.

Since this change makes it backward incompatible, semver increase can be done to `2.0.0` instead of `1.1.0`.
